### PR TITLE
Multi select: handle local feeds

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
@@ -51,7 +51,7 @@ public class EpisodesApplyActionFragment extends Fragment {
     private static final int ACTION_MARK_UNPLAYED = 8;
     public static final int ACTION_DOWNLOAD = 16;
     public static final int ACTION_DELETE = 32;
-    private static final int ACTION_ALL = ACTION_ADD_TO_QUEUE | ACTION_REMOVE_FROM_QUEUE
+    public static final int ACTION_ALL = ACTION_ADD_TO_QUEUE | ACTION_REMOVE_FROM_QUEUE
             | ACTION_MARK_PLAYED | ACTION_MARK_UNPLAYED | ACTION_DOWNLOAD | ACTION_DELETE;
     private Toolbar toolbar;
 
@@ -101,10 +101,6 @@ public class EpisodesApplyActionFragment extends Fragment {
                 new ActionBinding(ACTION_DELETE,
                         R.id.delete_batch, this::deleteChecked)
                 );
-    }
-
-    public static EpisodesApplyActionFragment newInstance(List<FeedItem> items) {
-        return newInstance(items, ACTION_ALL);
     }
 
     public static EpisodesApplyActionFragment newInstance(List<FeedItem> items, int actions) {
@@ -449,7 +445,7 @@ public class EpisodesApplyActionFragment extends Fragment {
         // download the check episodes in the same order as they are currently displayed
         List<FeedItem> toDownload = new ArrayList<>(checkedIds.size());
         for (FeedItem episode : episodes) {
-            if (checkedIds.contains(episode.getId()) && episode.hasMedia()) {
+            if (checkedIds.contains(episode.getId()) && episode.hasMedia() && !episode.getFeed().isLocalFeed()) {
                 toDownload.add(episode);
             }
         }

--- a/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/EpisodesApplyActionFragment.java
@@ -469,10 +469,8 @@ public class EpisodesApplyActionFragment extends Fragment {
     }
 
     private void close(@PluralsRes int msgId, int numItems) {
-        if (numItems > 0) {
-            ((MainActivity) getActivity()).showSnackbarAbovePlayer(
-                    getResources().getQuantityString(msgId, numItems, numItems), Snackbar.LENGTH_LONG);
-        }
+        ((MainActivity) getActivity()).showSnackbarAbovePlayer(
+                getResources().getQuantityString(msgId, numItems, numItems), Snackbar.LENGTH_LONG);
         getActivity().getSupportFragmentManager().popBackStack();
     }
 

--- a/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/FeedItemlistFragment.java
@@ -257,8 +257,14 @@ public class FeedItemlistFragment extends Fragment implements AdapterView.OnItem
                 if (!FeedMenuHandler.onOptionsItemClicked(getActivity(), item, feed)) {
                     switch (item.getItemId()) {
                         case R.id.episode_actions:
+                            int actions = EpisodesApplyActionFragment.ACTION_ALL;
+                            if (feed.isLocalFeed()) {
+                                // turn off download and delete actions for local feed
+                                actions ^= EpisodesApplyActionFragment.ACTION_DOWNLOAD;
+                                actions ^= EpisodesApplyActionFragment.ACTION_DELETE;
+                            }
                             EpisodesApplyActionFragment fragment = EpisodesApplyActionFragment
-                                    .newInstance(feed.getItems());
+                                    .newInstance(feed.getItems(), actions);
                             ((MainActivity)getActivity()).loadChildFragment(fragment);
                             return true;
                         case R.id.rename_item:


### PR DESCRIPTION
Code changes for requirement "Multi select should handle local files" in https://github.com/AntennaPod/AntennaPod/pull/4193.

I did the following changes to handle local feeds in multi select:

1. Hide actions "Download" and "Delete" in feed item list for local feeds (`FeedItemlistFragment`).
2. In queue list (`EpisodesApplyActionFragment`):
    * Download action: Ignore file download if feed is local.
    * Delete action: Item will only be removed from queue, no media file will be deleted (no code change needed here).

I hope this contribution helps. Did I miss something?